### PR TITLE
Match any format of version number

### DIFF
--- a/index.js
+++ b/index.js
@@ -90,8 +90,8 @@ WebpackCordovaPlugin.prototype.apply  = function(compiler){
       }
       try {
         replace({
-          regex: /version=\"([0-9]+\.?){1,3}\"/,
-          replacement: "version=\""+version+"\"",
+          regex: /version="[0-9a-zA-Z.-]+"/,
+          replacement: 'version="'+version+'"',
           paths: [config],
           silent: true
         });


### PR DESCRIPTION
If you use a pre-release version number, webpack-cordova-plugin stops updating the config.xml because the regex used does not match `-` or letters. This pull request alters the regex so that the following version number formats will work with the plugin:
- `1.0.0`
- `1.0.0-1`
- `1.0.0-alpha`
- `1.0.0-alpha.1`
- `1.0.0-1A`
- ...many other combinations of numbers, dots, letters, and dashes.
